### PR TITLE
Autocombine "Defrag"

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2009-2014 The Bitcoin developers
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2017 The PIVX developers
+// Copyright (c) 2018-2019 The GambleCoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -67,7 +68,7 @@ static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
 /** Default for accepting alerts from the P2P network. */
 static const bool DEFAULT_ALERTS = true;
 /** The maximum size for transactions we're willing to relay/mine */
-static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
+static const unsigned int MAX_STANDARD_TX_SIZE = 200000;
 static const unsigned int MAX_ZEROCOIN_TX_SIZE = 150000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const unsigned int MAX_BLOCK_SIGOPS_CURRENT = MAX_BLOCK_SIZE_CURRENT / 50;

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2156,6 +2156,8 @@ UniValue autocombinerewards(const UniValue& params, bool fHelp)
             "\nWallet will automatically monitor for UTXOs with values below the threshold amount, "
             "and combine them into transactions sized to the threshold amount, if they reside with "
             "the same UCC address.\n"
+            "\nA threshold value of \"0\" will combine all the UTXOs, up to the maximum possible "
+            "within the maximum transaction size of a block.\n"
             "\nA frequency value of \"0\" will run the combine once, on the next available block, "
             "and once again on each wallet startup.\n"
             "\nWhen autocombinerewards runs it will create a transaction, and therefore will be subject "

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -4051,7 +4051,9 @@ void CWallet::AutoCombineDust()
             nTotalRewardsValue += out.Value();
 
             // Combine until our total is enough above the threshold to remain above after adjustments
-            if ((nTotalRewardsValue - nTotalRewardsValue / 10) > nAutoCombineThreshold * COIN)
+            // If no threshold; we want to combine up to MAX_STANDARD_TX_SIZE
+            if (nAutoCombineThreshold && 
+                ((nTotalRewardsValue - nTotalRewardsValue / 10) > nAutoCombineThreshold * COIN))
                 break;
 
             // Around 180 bytes per input. We use 190 to be certain
@@ -4061,6 +4063,9 @@ void CWallet::AutoCombineDust()
                 break;
             }
         }
+
+        LogPrintf("AutoCombineDust: HasSelected: %d, size: %d, txSizeEstimate: %d, maxSize: %d\n",
+                  coinControl->HasSelected(), vRewardCoins.size(), txSizeEstimate, maxSize);
 
         //if no inputs found then return
         if (!coinControl->HasSelected())


### PR DESCRIPTION
Changed the autocombine functionality to redefine the behavior when the threshold is set to zero.  Instead of a zero threshold combining two small specs of dust; it now will combine the whole wallet, up to the transaction limit.

In other words; if there's 2000 UTXOs in the wallet, it will combine the first 630ish.  On subsequent passes it will combine the next set, and the next set; until it's all combined.

If using it as a single shot:
`setautocombinerewards true 0 0`
It will run it once and combine what it can, and then run it every time you start the wallet.

If you want to set it to combine once per day (presuming the wallet is open when the block occurs):
`setautocombinerewards true 0 800`

Or once per week: `setautocombinerewards true 0 5600`

This change also increases the max limit from 100k bytes to 200k bytes.