### PR TITLE
Fix Block Reward Calculations

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3583,7 +3583,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     LogPrint("bench", "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs]\n", (unsigned)block.vtx.size(), 0.001 * (nTime1 - nTimeStart), 0.001 * (nTime1 - nTimeStart) / block.vtx.size(), nInputs <= 1 ? 0 : 0.001 * (nTime1 - nTimeStart) / (nInputs - 1), nTimeConnect * 0.000001);
 
     //PoW phase redistributed fees to miner. PoS stage destroys fees.
-    CAmount nExpectedMint = GetBlockValue(pindex->pprev->nHeight);
+    CAmount nExpectedMint = GetBlockValue(pindex->nHeight);
     if (block.IsProofOfWork())
         nExpectedMint += nFees;
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -300,19 +300,16 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, int64_t nFe
         }
     }
 
-    CAmount blockValue = GetBlockValue(pindexPrev->nHeight);
-    CAmount masternodePayment = GetMasternodePayment(pindexPrev->nHeight, blockValue);
-
-    // txNew.vout[0].nValue = blockValue;
+    CAmount blockValue = GetBlockValue(pindexPrev->nHeight + 1);
+    CAmount masternodePayment = GetMasternodePayment(pindexPrev->nHeight + 1, blockValue);
 
     if (hasPayment) {
         if (fProofOfStake) {
-            /**For Proof Of Stake vout[0] must be null
+            /*
              * Stake reward can be split into many different outputs, so we must
              * use vout.size() to align with several different cases.
              * An additional output is appended as the masternode payment
              */
-            // txNew.vout[0].SetNull();
             unsigned int i = txNew.vout.size();
             txNew.vout.resize(i + 1);
             txNew.vout[i].scriptPubKey = payee;


### PR DESCRIPTION
When creating a new block, the blockreward being used was the block reward at the current chain height, not the block reward for the height that the chain would be once this new block is added.  This inadvertently minted one extra block at the previous halving level.  

This was not caught in consensus, because it also was calculating the block reward off the previous block, not the current block that it validates.  So two wrongs didn't make it right, but made it functional.

Lastly, because the payee checks during consensus only check to make sure the block creator isn't trying to short change the masternodes, that code didn't care that the block creator was giving twice as much to the masternode then it should have... on those crossover blocks.

This corrects both sides, having the block creation look ahead in the rewards table for the reward relevant to the block being created, not the previous block created.  Likewise the consensus looks up the current height of the block being validated, rather than the previous height.

This addresses PR #30 